### PR TITLE
New Settings: python command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ The extension can be activated with
 1. Toggle Preview (<kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> for Mac, <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> for Windows)
 2. Command `Preview Diagrams` to load the diagrams on a separate window on the right
 
+### Configurations
+We provide the following settings to the extension:
+
+|       | type | default |     |
+| -------| ------- |-----|-----|
+| diagramspreviewer.pythonCommand|string|default| Currently, this setting only affected Mac users. By default, python3 is installed in Mac and has to run as `python3`, but if you have set python3 as default (`python`), then you have to select `python` option here.
+
 ## Requirements (Set up)
 Make sure you have installed the following before activating the extension:
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,22 @@
         "command": "diagramspreviewer.start",
         "title": "Preview Diagrams"
       }
-    ]
+    ],
+    "configuration": {
+      "type":"object",
+      "title": "Diagrams Previewer",
+      "properties": {
+        "diagramspreviewer.pythonCommand":{
+          "enum": [
+            "default",
+            "python",
+            "python3"
+          ],
+          "default": "default",
+          "description": "The python command that runs version 3 of python on your machine"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,9 +5,22 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { platform } from 'process';
 
+let python3Commmand:string | undefined
+function initSettings() {
+	const workspace = vscode.workspace;
+    var settings = workspace.getConfiguration('diagramspreviewer');
+
+	python3Commmand = settings.get("pythonCommand")
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+
+	// settings
+	initSettings()
+	
+	// commmands
 	const command = 'diagramspreviewer.start';
 
 	const docPath = () => vscode.window.activeTextEditor?.document.uri.path ?? "";
@@ -58,8 +71,17 @@ export function activate(context: vscode.ExtensionContext) {
 	const executionCommand = () => {
 		if (platform == 'win32')
 			return `py ${targetSrcFileName}`;
-		else
-			return `python3 ${targetSrcFileName}`;
+		else {
+			let macCommand = `python3 ${targetSrcFileName}`
+			switch (python3Commmand) {
+				case 'python': {
+					macCommand = `${python3Commmand} ${targetSrcFileName}`;
+					break;
+				}
+			}
+
+			return macCommand
+		}
 	}
 
 	const generateDiagram = async (panel: vscode.WebviewPanel) => {
@@ -199,6 +221,10 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
+
+	vscode.workspace.onDidChangeConfiguration(function () {
+        initSettings();
+    }, null, context.subscriptions);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
In Mac, while python3 is the default command line to run python scripts in version 3, but some users may have set python3 as their default version. This resulted in them running the scripts using `python` instead of `python3` on their machine.

To support this scenario, we will be introducing a new setting for users to set the python command to use. 