### PR TITLE
Ignore filename argument

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,7 +129,7 @@ export function activate(context: vscode.ExtensionContext) {
 		// Form `withDiagram` line
 		let withDiagram = 'with Diagram(';
 		args.forEach(x => {
-			if (!x.includes('fileName')) 
+			if (!x.toLowerCase().includes('filename')) 
 				withDiagram = `${withDiagram}${x},`
 		});
 		withDiagram = `${withDiagram}filename="${fileName}",`


### PR DESCRIPTION
Currently, the code ignores the filename argument explicitly by `fileName`. Hence, it will fail cases where `filename` is used instead. 

This PR is to compare the argument in a case insensitive manner. 