### PR TITLE
Support using VS Code python extension interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,8 @@ All notable changes to the "diagramasacodepreview" extension will be documented 
 ## [1.0.5]
 - New settings: Configure your own python command
 - Updated README.md - on the settings configurations available
+
+## [1.0.6]
+- Support using [VS Code's python extension's interpreter](https://code.visualstudio.com/docs/python/environments#_manually-specify-an-interpreter) via introducting new option 
+(`VS Code Python Interpreter`) to python command configuration
+- Updated README.md - on the settings configurations available

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We provide the following settings to the extension:
 
 |       | type | default |     |
 | -------| ------- |-----|-----|
-| diagramspreviewer.pythonCommand|string|default| Currently, this setting only affected Mac users. By default, python3 is installed in Mac and has to run as `python3`, but if you have set python3 as default (`python`), then you have to select `python` option here.
+| diagramspreviewer.pythonCommand|string|default| 🆕 option: "VS Code Python Interpreter". This option will use the interpreter set on [VS Code's python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and it will be applicable to any platform (Windows / Mac). <br/><br/>The other options will only apply to Mac platform.
 
 ## Requirements (Set up)
 Make sure you have installed the following before activating the extension:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "diagramspreviewer",
   "displayName": "Diagrams Previewer",
   "description": "Translate the code into diagrams",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "tehpeng",
   "author": {
     "name": "Chia Li Yun"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
           "enum": [
             "default",
             "python",
-            "python3"
+            "python3",
+            "VS Code Python Interpreter"
           ],
           "default": "default",
           "description": "The python command that runs version 3 of python on your machine"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	const executionCommand = async () => {
-		if (python3Commmand === 'default') {
+		if (python3Commmand === 'VS Code Python Interpreter') {
 			const path = await getVSCodePythonEnv()
 			vscode.window.showInformationMessage(`default: ${path} ${targetSrcFileName}}`)
 			return `${path} ${targetSrcFileName}`
@@ -137,8 +137,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// execute command
 		proc.exec(cmd, { cwd: outDirectory }, (err: string, stdout: string, stderr: string) => {
-			vscode.window.showInformationMessage("hello.");
-
 			if (err) {
 				vscode.window.showErrorMessage("Error executing the code, please make sure you have Python3 (3.6 or higher) with the relevant packages (diagrams) and Graphviz installed. You may refer to the Requirements section for more information.");
 


### PR DESCRIPTION
Some users may be using virtual environment instead of the default local python set up and they will not be able to use this extension as we leverage solely on the local set up.

Add support to use interpreter that is set to VS Code python extension as reported in the [issue](https://github.com/chialiyun/DiagramsPreviewerVSCExt/issues/5) - this will allow users to use virtual environment set up.